### PR TITLE
Fix chromium previous sessions removal

### DIFF
--- a/home/.xsession
+++ b/home/.xsession
@@ -26,7 +26,7 @@ if [ -f .config/chromium/Default/Preferences ]; then
 fi
 
 # Remove notes of previous sessions, if any
-find .config/chromium/ -name "Last *" | xargs rm
+find .config/chromium/ -name "Last *" -exec rm {} +
 
 # Start and detach Chromium
 # http://peter.sh/experiments/chromium-command-line-switches/


### PR DESCRIPTION
Removing notes from previous sessions was filing due to path containing spaces (.config/chromium/Last Session) being passed to rm command. find with exec handles that case better